### PR TITLE
docs: add Hanzilla Jobs to job search resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ All of the programs are all expenses paid. Most of those programs have GPA requi
 | --- | --- |
 | [Simplify](https://simplify.jobs/) | Auto fills job applications |
 | [JobPulse](https://jobpulse.fyi/) | Connects students to potential company matches |
+| [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) | Daily-updated Canadian student and new-grad jobs board with internships, co-ops, junior roles, and tech/data categories |
 | [Levels.FYI](https://www.levels.fyi/) | Transparent job salary, offer negotiations, and community services for tech jobs |
 | [Layoffs.FYI](https://www.layoffs.fyi/) | Transparent job market data on layoffs based on location, company, and industry |
 | [KnowTern](https://www.knowtern.com/database) | Diversity opportunities database |


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs to the Job Searching, Applying, and Market Tracking resources table.
- It is a free daily-updated Canadian student/recent-grad jobs board covering internships, co-ops, junior/new-grad roles, and relevant tech/data categories.

## Why it fits
The resource hub already lists tools students can use for job search and market tracking. Hanzilla Jobs is especially useful for Canadian students looking for internships/co-ops/new-grad roles without having to check many company career pages manually.

## Test plan
- Markdown-only change.
- Ran `git diff --check`.
